### PR TITLE
current_python_frame: Fix NULL ThreadState

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ flamegraph.pl prof-$PID.txt > prof-$PID.svg
 [2] The "debug" Python binary is built with `--with-pydebug`, which also builds the interpreter with `-O0`, and enables the debug memory allocator. Those changes can negatively affect application performance, when all we really need here is a binary with DWARF debugging symbols in it. If this is a factor, consider building your own Python binary instead. E.g. (untested)
 ```
 export $VER=2.7.11
-wget https://www.python.org/ftp/python/$RELEASE/Python-$VER.tar.xz
-tar -xzvf Python-$VER.tar.xz
-cd Python-$VER.tar.xz
+wget https://www.python.org/ftp/python/$VER/Python-$VER.tar.xz
+tar -xvJf Python-$VER.tar.xz
+cd Python-$VER
 ./configure CFLAGS='-g -fno-omit-frame-pointer' --prefix=/opt/python-$VER-dbg
 make
 sudo make install

--- a/pysample.stp
+++ b/pysample.stp
@@ -43,6 +43,9 @@ function unpack_ustack () {
 
 function current_python_frame() {
     pythreadstate = @var("_PyThreadState_Current@Python/pystate.c", @PYTHON_LIBRARY);
+    if (pythreadstate == 0) {
+        return 0
+    }
     return @cast(pythreadstate, "PyThreadState", @PYTHON_LIBRARY)->frame;
 }
 


### PR DESCRIPTION
The bug can reproduced through:

``` python
import os
import time


def fn():
    print time.time()
    time.sleep(1)


def add():
    j = 0
    for i in range(1000000):
        j += i
    return j


def main():
    print(os.getpid())
    while True:
        fn()
        add()


if __name__ == '__main__':
    main()
```

An error occurs after`sudo ./pystap -x $PID`

```
ERROR: read fault [man error::fault] at 0x0000000000000010 (addr) near operator '@cast' at ./pysample.stp:46:12
```
