### PR TITLE
sample: Compatible with python built with --enable-shared

### DIFF
--- a/scripts/sample
+++ b/scripts/sample
@@ -11,11 +11,21 @@ def abspath(f):
     return os.path.join(os.path.dirname(__file__), f)
 
 shared_library_re = re.compile("\.so[0-9\.]*$")
+libpython_re = re.compile(r'\t.* => (.*libpython.*) \(0x')
 
 
 def gen_tapset_macros(binary, tapset_dir):
+    python_lib_path = binary
+    lines = subprocess.check_output(["ldd", binary]).splitlines()
+    for line in lines:
+        m = libpython_re.match(line)
+        if not m:
+            continue
+        python_lib_path = m.group(1)
+        break
+
     with open(os.path.join(tapset_dir, 'py_library.stpm'), 'w') as f:
-        f.write('@define PYTHON_LIBRARY %( "{}" %)'.format(binary))
+        f.write('@define PYTHON_LIBRARY %( "{}" %)'.format(python_lib_path))
 
 
 def main():


### PR DESCRIPTION
The basic idea comes from https://github.com/eklitzke/pystack/blob/d0f847d/src/pyframe.cc#L133-L149 

> The default way Python is compiled you
> get a "static" build which means that you get a big several-megabytes
> Python executable that has all of the symbols statically built in. For
> instance, this is how Python is built on Debian and Ubuntu. This is the
> easiest case to handle, since in this case there are no tricks, we just
> need to find the symbol in the ELF file.
> 
> There's also a configure option called --enable-shared where you get a
> small several-kilobytes Python executable that links against a
> several-megabytes libpython2.7.so. This is how Python is built on Fedora.
> If that's the case we need to do some fiddly things to find the true symbol
> location.
